### PR TITLE
Add --no-parallel option to publish command

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           cache-cleanup: always
 
-      - run: ./gradlew publishToMavenCentral
+      - run: ./gradlew publishToMavenCentral --no-parallel
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           cache-cleanup: always
 
+      # Build all artifacts with full parallelism.
+      - run: ./gradlew publishToMavenLocal
+
+      # Publish to Maven Central without parallelism to try and avoid rate limiting.
       - run: ./gradlew publishToMavenCentral --no-parallel
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}


### PR DESCRIPTION
🐳   Disable concurrent uploads for publishing to maven central to avoid 429 rate limiting - see https://www.sonatype.com/blog/maven-central-and-the-tragedy-of-the-commons 

💁  Attempt to try and see if this fixes the rate limiting seen in the last couple of weeks in all `publish_archives` multi-platform jar uploads - e.g [publish_archives](https://github.com/sqldelight/sqldelight/actions/runs/19803659444/job/56734558615#logs)

📚  Assumes that setting `./gradlew publishToMavenCentral --no-parallel` will affect publishing builds ?

Parallel was made the default a few weeks ago https://github.com/sqldelight/sqldelight/blob/ecbbb4ed58df24eea3b7fd79e42a410ba2c38978/gradle.properties#L3


---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
